### PR TITLE
Add callback as second parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ call contains a list of "blocks", whereas an `it` call contains the actual
 `code` in order to provide an effective, well-tested example.
 
 ```javascript
-    
+
     var contents =
-      '/**\n' + 
+      '/**\n' +
       ' * A `Model` is a convenience wrapper around objects stored in a\n' +
       ' * collection\n' +
       ' */\n' +
@@ -51,7 +51,27 @@ call contains a list of "blocks", whereas an `it` call contains the actual
     assert.equal('it', ret[0].blocks[1].type);
     assert.equal('can save with a parameter', ret[0].blocks[1].contents);
     assert.equal(0, ret[0].blocks[1].comments.length);
-  
+
+```
+
+#### Acquit can also take a callback as second parameter
+
+```javascript
+    var contents =
+    'describe(\'ES6\', function() {\n' +
+    '  // ES6 has a `yield` keyword\n' +
+    '  it(\'should be able to yield\', function() {\n' +
+    '    // some code\n' +
+    '  });\n' +
+    '});';
+
+    var cb = function(block) {
+    block.code = 'return value from callback';
+    };
+
+    var ret = acquit.parse(contents, cb);
+
+    assert.equal('return value from callback', ret[0].blocks[0].code);
 ```
 
 #### It can parse the ES6 `yield` keyword
@@ -59,8 +79,8 @@ call contains a list of "blocks", whereas an `it` call contains the actual
 Acquit can also parse ES6 code
 
 ```javascript
-    
-    var contents = 
+
+    var contents =
       'describe(\'ES6\', function() {\n' +
       '  // ES6 has a `yield` keyword\n' +
       '  it(\'should be able to yield\', function() {\n' +
@@ -79,7 +99,7 @@ Acquit can also parse ES6 code
     assert.equal('it', ret[0].blocks[0].type);
     assert.equal(1, ret[0].blocks[0].comments.length);
     assert.ok(ret[0].blocks[0].code);
-  
+
 ```
 
 ## `acquit.trimEachLine()`
@@ -90,13 +110,13 @@ Acquit can also parse ES6 code
 from JSdoc-style comments
 
 ```javascript
-    
+
     var str = '  * This comment looks like a \n' +
       '  * parsed JSdoc-style comment';
 
     assert.equal(acquit.trimEachLine(str), 'This comment looks like a\n' +
       'parsed JSdoc-style comment');
-  
+
 ```
 
 #### It strips out whitespace and asterisks in multiline comments
@@ -105,12 +125,11 @@ You don't have to use JSdoc-style comments: `trimEachLine()` also trims
 leading and trailing whitespace.
 
 ```javascript
-    
+
     var str = 'This comment looks like a \n' +
       '  * parsed JSdoc-style comment';
 
     assert.equal(acquit.trimEachLine(str), 'This comment looks like a\n' +
       'parsed JSdoc-style comment');
-  
-```
 
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,11 @@ var _ = require('underscore');
 var util = require('util');
 var marked = require('marked');
 
-var parse = function(contents) {
+var parse = function(contents, cb) {
+  if (arguments.length == 2 && !(typeof cb === 'function')) {
+    throw Error('Second parameter must be a function.');
+  }
+
   var tree = esprima.parse(contents, { attachComment: true });
 
   var visitorFactory = function() {
@@ -36,6 +40,9 @@ var parse = function(contents) {
           comments: _.pluck(node.callee.leadingComments || [], 'value'),
           code: contents.substring(node.arguments[1].body.range[0] + 1, node.arguments[1].body.range[1] - 1)
         };
+        if (typeof cb != 'undefined') {
+          cb(block);
+        }
         context.push(block);
         // Once we've reached an 'it' block, no need to go further
         return null;

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,7 @@ describe('`acquit.parse()`', function() {
    * `code` in order to provide an effective, well-tested example. */
   it('can parse Mocha tests into `blocks`', function() {
     var contents =
-      '/**\n' + 
+      '/**\n' +
       ' * A `Model` is a convenience wrapper around objects stored in a\n' +
       ' * collection\n' +
       ' */\n' +
@@ -48,10 +48,31 @@ describe('`acquit.parse()`', function() {
   });
 
   /**
+   * Acquit can also take a callback as second parameter
+   */
+  it('can call user function on `code` block and save return value', function() {
+    var contents =
+      'describe(\'ES6\', function() {\n' +
+      '  // ES6 has a `yield` keyword\n' +
+      '  it(\'should be able to yield\', function() {\n' +
+      '    // some code\n' +
+      '  });\n' +
+      '});';
+
+    var cb = function(block) {
+      block.code = 'return value from callback';
+    };
+
+    var ret = acquit.parse(contents, cb);
+
+    assert.equal('return value from callback', ret[0].blocks[0].code);
+  });
+
+  /**
    * Acquit can also parse ES6 code
    */
   it('can parse the ES6 `yield` keyword', function() {
-    var contents = 
+    var contents =
       'describe(\'ES6\', function() {\n' +
       '  // ES6 has a `yield` keyword\n' +
       '  it(\'should be able to yield\', function() {\n' +


### PR DESCRIPTION
Acquit tries to find matches in each `it` block's code field with provided pattern and if it finds one, it will run a callback on that match and save the result into block's `matches` field (you can have more matches of course).

The code below generates [API Blueprint](https://apiblueprint.org) and in particular it _loads_ request/response JSON from a file.

```js
var acquit = require('../acquit');
var fs = require('fs');

module.exports = function(content) {
  var cb = function(file) {
    if (file) {
      return fs.readFileSync(file).toString();
    }
  };

  // parse and load requests and responses
  var groups = acquit.parse(content, /(?:reqFile|resFile) = '(.*)'/g, cb);

  var doc = '';

  // groups
  for (var i in groups) {
    ...
    // resources
    for (var j in resources) {
      ...
      // actions
      for (var k in actions) {
        ...
        // request and response payload
        if ('matches' in test) {
          doc += formatPayload(test.matches[0], '+ Request (application/json)');
        }
      }
    }
  }

  return doc;
};
```

Example test:

```js
describe('Users', function() {
  describe('Users [/users/]', function() {
    describe('Create a user [POST]', function() {
      it('Returns user if user is created successfully.', function(done) {
        var reqFile = 'tests/user/createUserReq.json';
        api.post('/users/')
          .send(jsonfile.readFileSync(reqFile))
          .expect(200)
          .expect('Content-Type', /json/)
          .end(done);
      })
    });
  });
});
```