### PR TITLE
Support for Mocha's `context()` and `specify()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,33 @@ Acquit can also parse ES6 code
   
 ```
 
+#### It can parse Mocha's `context()` and `specify()`
+
+Acquit can parse Mocha alias:
+- `context` = `describe`
+- `specify` = `it`
+
+```javascript
+    
+    var contents =
+    'context(\'Mocha aliases\', function() {\n' +
+    '  specify(\'should be parsed\', function() {\n' +
+    '    assert.equal(1, 1);\n' +
+    '  });\n' +
+    '});';
+
+    var ret = acquit.parse(contents);
+
+    assert.equal(1, ret.length);
+    assert.equal('describe', ret[0].type);
+    assert.equal(0, ret[0].comments.length);
+    assert.equal(1, ret[0].blocks.length);
+    assert.equal('it', ret[0].blocks[0].type);
+    assert.equal(0, ret[0].blocks[0].comments.length);
+    assert.ok(ret[0].blocks[0].code);
+  
+```
+
 ## `acquit.trimEachLine()`
 
 #### It strips out whitespace and asterisks in multiline comments

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -18,7 +18,7 @@ module.exports = function(transforms, contents, cb) {
     ret.visit = function(node, parent, context) {
       if (node.type === 'ExpressionStatement' &&
           _.get(node, 'expression.type') === 'CallExpression' &&
-          _.get(node, 'expression.callee.name') === 'describe' &&
+          (_.get(node, 'expression.callee.name') === 'describe' || _.get(node, 'expression.callee.name') === 'context') &&
           _.get(node, 'expression.arguments.length', 0) > 0) {
         var block = {
           type: 'describe',
@@ -30,7 +30,7 @@ module.exports = function(transforms, contents, cb) {
         return block.blocks;
       } else if (node.type === 'ExpressionStatement' &&
           _.get(node, 'expression.type') === 'CallExpression' &&
-          _.get(node, 'expression.callee.name') === 'it' &&
+          (_.get(node, 'expression.callee.name') === 'it' || _.get(node, 'expression.callee.name') === 'specify') &&
           _.get(node, 'expression.arguments.length', 0) > 1) {
         var block = {
           type: 'it',

--- a/test/test.js
+++ b/test/test.js
@@ -122,6 +122,30 @@ describe('`acquit.parse()`', function() {
     assert.equal(1, ret[0].blocks[0].comments.length);
     assert.ok(ret[0].blocks[0].code);
   });
+
+  /**
+   * Acquit can parse Mocha alias:
+   *  - `context` = `describe`
+   *  - `specify` = `it`
+   */
+  it('can parse Mocha\'s `context()` and `specify()`', function() {
+    var contents =
+    'context(\'Mocha aliases\', function() {\n' +
+    '  specify(\'should be parsed\', function() {\n' +
+    '    assert.equal(1, 1);\n' +
+    '  });\n' +
+    '});';
+
+    var ret = acquit.parse(contents);
+
+    assert.equal(1, ret.length);
+    assert.equal('describe', ret[0].type);
+    assert.equal(0, ret[0].comments.length);
+    assert.equal(1, ret[0].blocks.length);
+    assert.equal('it', ret[0].blocks[0].type);
+    assert.equal(0, ret[0].blocks[0].comments.length);
+    assert.ok(ret[0].blocks[0].code);
+  });
 });
 
 describe('`acquit.trimEachLine()`', function() {


### PR DESCRIPTION
Hi

This is a simple pull request to support `context()` and `specify()` aliases.

Thanks again and sry for the mess with #16 