### PR TITLE
Fix all security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,17 +23,16 @@
     "url": "git://github.com/vkarpov15/acquit.git"
   },
   "dependencies": {
-    "esprima": "4.0.0",
-    "marked": "0.3.9"
+    "esprima": "4.0.0"
   },
   "devDependencies": {
     "acquit-ignore": "0.1.0",
     "acquit-markdown": "0.1.0",
     "acquit-require": "0.1.1",
     "highlight.js": "9.12.0",
-    "marked": "0.4.0",
-    "mocha": "5.2.0",
-    "nyc": "11.8.0",
+    "marked": "^1.1.1",
+    "mocha": "^8.1.3",
+    "nyc": "^15.1.0",
     "serve": "11.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
     "url": "git://github.com/vkarpov15/acquit.git"
   },
   "dependencies": {
-    "esprima": "4.0.0"
+    "esprima": "4.0.0",
+    "marked": "^1.1.1"
   },
   "devDependencies": {
     "acquit-ignore": "0.1.0",
     "acquit-markdown": "0.1.0",
     "acquit-require": "0.1.1",
     "highlight.js": "9.12.0",
-    "marked": "^1.1.1",
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",
     "serve": "11.x"


### PR DESCRIPTION
NPM audit shows `172 Security Vulnerabilities`... upgrading `Marked`, `Mocha` and `NYC` (_Istanbul_) resolves these.