### PR TITLE
Change `esprima` to `espree`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ logs
 *.log
 
 package-lock.json
+yarn.lock
 
 # Runtime data
 pids

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -15,7 +15,7 @@ module.exports = function(transforms, contents, cb) {
 
     ret.result = {};
     var existingRanges = [];
-    var existingDescribeRanges = []
+    var existingDescribeRanges = [];
     var blockFns = ['it', 'specify'];
 
     ret.visit = function(node, parent, context) {
@@ -29,7 +29,7 @@ module.exports = function(transforms, contents, cb) {
           type: 'describe',
           contents: node.expression.arguments[0].value,
           blocks: [],
-          comments: (_comments || []).map(v => v.value)
+          comments: _comments.map(v => v.value)
         };
         context.push(block);
         return block.blocks;
@@ -42,7 +42,7 @@ module.exports = function(transforms, contents, cb) {
         var block = {
           type: 'it',
           contents: node.expression.arguments[0].value,
-          comments: (_comments || []).map(v => v.value),
+          comments: _comments.map(v => v.value),
           code: formatCode(contents.substring(node.expression.arguments[1].body.range[0] + 1, node.expression.arguments[1].body.range[1] - 1))
         };
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var esprima = require('esprima');
+var espree = require('espree');
 var formatCode = require('./formatCode');
 
 module.exports = function(transforms, contents, cb) {
@@ -8,13 +8,14 @@ module.exports = function(transforms, contents, cb) {
     throw Error('Second parameter must be a function.');
   }
 
-  var tree = esprima.parseModule(contents, { attachComment: true, range: true });
+  var tree = espree.parse(contents, { comment: true , range: true, ecmaVersion: "latest", sourceType: "module" });
 
   var visitorFactory = function() {
     var ret = {};
 
     ret.result = {};
     var existingRanges = [];
+    var existingDescribeRanges = []
     var blockFns = ['it', 'specify'];
 
     ret.visit = function(node, parent, context) {
@@ -22,11 +23,13 @@ module.exports = function(transforms, contents, cb) {
           get(node, 'expression.type') === 'CallExpression' &&
           (get(node, 'expression.callee.name') === 'describe' || get(node, 'expression.callee.name') === 'context') &&
           get(node, 'expression.arguments.length', 0) > 0) {
+        var _comments = getComments(existingRanges, existingDescribeRanges, tree, node.range, 'describe');
+        existingDescribeRanges.push(node.range);
         var block = {
           type: 'describe',
           contents: node.expression.arguments[0].value,
           blocks: [],
-          comments: takeRight((node.leadingComments || []).map(v => v.value))
+          comments: (_comments || []).map(v => v.value)
         };
         context.push(block);
         return block.blocks;
@@ -34,12 +37,7 @@ module.exports = function(transforms, contents, cb) {
           get(node, 'expression.type') === 'CallExpression' &&
           blockFns.indexOf(get(node, 'expression.callee.name')) !== -1 &&
           get(node, 'expression.arguments.length', 0) > 1) {
-        // Weird but esprima sometimes treats the last comment in a previous
-        // `it()` block as a leading comment for the next `it()` block, so
-        // filter out comments that are in other `it()` blocks.
-        var _comments = existingRanges.length === 0 ?
-          node.leadingComments :
-          (node.leadingComments || []).filter(c => c.range[0] > last(existingRanges)[1]);
+        var _comments = getComments(existingRanges, existingDescribeRanges, tree, node.range, 'it');
         existingRanges.push(node.range);
         var block = {
           type: 'it',
@@ -89,8 +87,44 @@ module.exports = function(transforms, contents, cb) {
   return ret;
 };
 
-function takeRight(arr) {
-  return arr.slice(arr.length - 1);
+/**
+ * Get all comments within range for the given block
+ * @param {[[number, number]]} existingRanges The inner block ranges
+ * @param {[[number, number]]} existingDescribeRanges The describe block ranges
+ * @param {*} tree The tree where the comments are on
+ * @param {[number, number]} range The range of the current node
+ * @param {"describe" | "it"} type The type to get comments for
+ * @returns {[string]} The filtered comments
+ */
+function getComments(existingRanges, existingDescribeRanges, tree, range, type) {
+  if (!tree.comments || tree.comments.length === 0) {
+    return [];
+  }
+
+  var lastRange;
+
+  if (type === "describe") {
+    // for "describe" block comments, only use describe block ranges
+    lastRange = last(existingDescribeRanges) || [0, 0];
+  } else if (type === "it") {
+    // for "it"(or inner) block's, use last inner range
+    // OR use last describe block's beginning and only the beginning
+    // OR if the last describe block's beginning is higher than the last inner block,
+    // use describe block's beginning
+    lastRange = last(existingRanges);
+    var lastDescribe = last(existingDescribeRanges) || [0, 0];
+    if (!lastRange || lastRange[1] < lastDescribe[0]) {
+      lastRange = [lastDescribe[0], lastDescribe[0]];
+    }
+  } else {
+    throw new Error('Unknown type "'+type+'"');
+  }
+
+  return tree.comments.filter(c => {
+    var commentBegin = c.range[0];
+    var commentEnd = c.range[1];
+    return commentBegin > lastRange[1] && commentEnd < range[0];
+  })
 }
 
 function get(obj, prop) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
     "url": "git://github.com/vkarpov15/acquit.git"
   },
   "dependencies": {
-    "esprima": "4.0.1"
+    "espree": "~9.6.1"
+  },
+  "engines": {
+    "node": ">=12.22.0"
   },
   "devDependencies": {
     "acquit-ignore": "0.1.0",

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -190,6 +190,24 @@ describe('third', () => {
     assert.equal(ret[2].comments.length, 0);
     assert.equal(ret[2].blocks[0].comments.length, 0);
   })
+
+  it('supports spread operator', function() {
+    var contents = `
+    const obj = {
+  name: "My Object"
+};
+
+it("should parse spread syntax", async () => {
+  const newObj = { key: { ...obj, newKey: "newValue" } };
+});`;
+
+    var ret = acquit.parse(contents);
+
+    assert.equal(ret.length, 1);
+
+    assert.equal(ret[0].type, "it");
+    assert.equal(ret[0].contents, "should parse spread syntax");
+  })
 });
 
 describe('`acquit.trimEachLine()`', function() {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -197,7 +197,7 @@ describe('third', () => {
   name: "My Object"
 };
 
-it("should parse spread syntax", async () => {
+it("should parse spread syntax", () => {
   const newObj = { key: { ...obj, newKey: "newValue" } };
 });`;
 
@@ -208,6 +208,39 @@ it("should parse spread syntax", async () => {
     assert.equal(ret[0].type, "it");
     assert.equal(ret[0].contents, "should parse spread syntax");
   })
+
+  it('supports async function', function () {
+    var contents = `
+it("should parse async fn", async function() {
+  await somePromise();
+});`;
+
+    var ret = acquit.parse(contents);
+
+    assert.equal(ret.length, 1);
+
+    assert.equal(ret[0].type, "it");
+    assert.equal(ret[0].contents, "should parse async fn");
+  });
+
+  it('supports generators', function () {
+    var contents = `
+it("should parse generator fn", function() {
+  function* someGen() {
+    yield 0;
+    yield 1;
+  }
+  const gen = someGen();
+  console.log(gen.next());
+});`;
+
+    var ret = acquit.parse(contents);
+
+    assert.equal(ret.length, 1);
+
+    assert.equal(ret[0].type, "it");
+    assert.equal(ret[0].contents, "should parse generator fn");
+  });
 });
 
 describe('`acquit.trimEachLine()`', function() {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -151,6 +151,45 @@ describe('`acquit.parse()`', function() {
     assert.equal(0, ret[0].blocks[0].comments.length);
     assert.ok(ret[0].blocks[0].code);
   });
+
+  // https://github.com/vkarpov15/acquit/issues/30
+  it('does not carry comments from last describe block to next', function() {
+    var contents = `
+    // this is fine
+describe('first', () => {
+  it('hello', () => {
+    assert(1 == 1);
+    // some random last comment
+  });
+});
+
+describe('second', () => {
+  it('another', () => {
+    assert(2 == 2);
+  });
+});
+
+describe('third', () => {
+  it('final', () => {
+    assert(3 == 3);
+  });
+});
+    `
+
+    var ret = acquit.parse(contents);
+
+    assert.equal(ret.length, 3);
+
+    assert.equal(ret[0].comments.length, 1);
+    assert.equal(ret[0].comments[0], " this is fine");
+    assert.equal(ret[0].blocks[0].comments.length, 0);
+
+    assert.equal(ret[1].comments.length, 0);
+    assert.equal(ret[1].blocks[0].comments.length, 0);
+
+    assert.equal(ret[2].comments.length, 0);
+    assert.equal(ret[2].blocks[0].comments.length, 0);
+  })
 });
 
 describe('`acquit.trimEachLine()`', function() {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,5 +1,4 @@
 var assert = require('assert');
-var fs = require('fs');
 var acquit = require('../lib');
 
 describe('`acquit.parse()`', function() {
@@ -33,13 +32,14 @@ describe('`acquit.parse()`', function() {
     assert.equal(1, ret.length);
     assert.equal('describe', ret[0].type);
     assert.equal(1, ret[0].comments.length);
-    assert.ok(ret[0].comments[0].indexOf('Model') != -1);
+    assert.ok(ret[0].comments[0].indexOf('convenience') != -1);
 
     // Top-level block contains the `it('can save')` block, which contains
     // the code
     assert.equal(2, ret[0].blocks.length);
     assert.equal('it', ret[0].blocks[0].type);
     assert.equal(1, ret[0].blocks[0].comments.length);
+    assert.ok(ret[0].blocks[0].comments[0].indexOf('**should**') != -1);
     assert.ok(ret[0].blocks[0].code.indexOf('assert.ok(1)') !== -1);
     assert.equal('can save', ret[0].blocks[0].contents);
 


### PR DESCRIPTION
This PR changes the dependency on `esprima`, which has not been updated for over 7 years, to `espree`, which is to my knowledge, is still used by eslint.
This does not use the latest version of `espree` to support node versions older than `18`. Minimal NodeJS version is now `12.22`.

`espree` handles comments differently than `esprima` 4.0 did, it (according to the documentation) handles it like esprima 1.2, which required adjustment here. This coincidentally also:
- fixes #30 
- fixes #23
- fixes #18

This PR has been run against current mongoose(`7cab712f9138ec4e9eee367790efce297148f06d`) and kareem (https://github.com/mongoosejs/kareem/pull/41) and the only change was that now in the kareem PR the added `// NOTE:` is also seen as a comment, or said differently, it now collects more comments where it (hopefully) makes sense.

Also to note is that now we have to specify what ECMAScript Version and which module type we want to parse.
I have chosen ECMAScript version `latest` so that acquit "just works", anything else should be catched by eslint.
Additionally, i have chosen module type `module` as this, at least currently, allows parsing `require` AND `import / export` without error-ing or requiring a config on acquit's part.

PS: i would recommend to put this into a acquit 2.0 version or something.